### PR TITLE
fix: correct cliente registration endpoint in SecurityConfig

### DIFF
--- a/src/main/java/com/barbearia/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/barbearia/infrastructure/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/",
                     "/docs",
-                    "/api/auth/cliente/registro",
+                    "/api/auth/cliente/registrar",
                     "/api/auth/cliente/login",
                     "/api/auth/barbearia/registrar",
                     "/api/hello",


### PR DESCRIPTION
## Fix: Cliente Registration Endpoint

Fixed SecurityConfig to allow public access to `/api/auth/cliente/registrar` endpoint.

**Changed:** `/api/auth/cliente/registro` → `/api/auth/cliente/registrar`

**Impact:** Cliente registration now works correctly without authentication.

**Tinha definido na proteção de rota como /regitro e era /registrar, isso tava gerando o erro de sem autorização na rota**